### PR TITLE
Use FlaskForm instead Form

### DIFF
--- a/flasktaskr-02/project/forms.py
+++ b/flasktaskr-02/project/forms.py
@@ -1,13 +1,13 @@
 # project/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from wtforms import StringField, DateField, IntegerField, \
     SelectField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo
 
 
-class AddTaskForm(Form):
+class AddTaskForm(FlaskForm):
     task_id = IntegerField()
     name = StringField('Task Name', validators=[DataRequired()])
     due_date = DateField(
@@ -25,7 +25,7 @@ class AddTaskForm(Form):
     status = IntegerField('Status')
 
 
-class RegisterForm(Form):
+class RegisterForm(FlaskForm):
     name = StringField(
         'Username',
         validators=[DataRequired(), Length(min=6, max=25)]
@@ -43,7 +43,7 @@ class RegisterForm(Form):
     )
 
 
-class LoginForm(Form):
+class LoginForm(FlaskForm):
     name = StringField(
         'Username',
         validators=[DataRequired()]


### PR DESCRIPTION
Form is renamed to FlaskForm in order to avoid name collision with WTForms's base class. Using Form will show a deprecation warning. (#250)