### PR TITLE
Redundant request form get values

### DIFF
--- a/flask-blog/blog.py
+++ b/flask-blog/blog.py
@@ -72,8 +72,7 @@ def add():
         g.db = connect_db()
         g.db.execute(
             'insert into posts (title, post) values (?, ?)',
-            [request.form['title'], request.form['post']]
-        )
+            [title, post])
         g.db.commit()
         g.db.close()
         flash('New entry was successfully posted!')


### PR DESCRIPTION
Since `title` and `post` are already in function scope, we don't need to get values from `request.form` again