### PR TITLE
flask_wtf.Form renamed to flask_wtf.FlaskForm

### DIFF
--- a/assets/flasktaskr-05/tasks/forms.py
+++ b/assets/flasktaskr-05/tasks/forms.py
@@ -1,4 +1,4 @@
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, DateField, IntegerField, \
     SelectField
 from wtforms.validators import DataRequired

--- a/assets/flasktaskr-05/users/forms.py
+++ b/assets/flasktaskr-05/users/forms.py
@@ -1,4 +1,4 @@
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo, Email
 

--- a/flasktaskr-01/project/forms.py
+++ b/flasktaskr-01/project/forms.py
@@ -1,7 +1,7 @@
 # project/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, DateField, IntegerField, \
     SelectField
 from wtforms.validators import DataRequired

--- a/flasktaskr-02/project/forms.py
+++ b/flasktaskr-02/project/forms.py
@@ -1,7 +1,7 @@
 # project/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, DateField, IntegerField, \
     SelectField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo

--- a/flasktaskr-03/project/forms.py
+++ b/flasktaskr-03/project/forms.py
@@ -1,7 +1,7 @@
 # project/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, DateField, IntegerField, \
     SelectField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo, Email

--- a/flasktaskr-04/project/forms.py
+++ b/flasktaskr-04/project/forms.py
@@ -1,7 +1,7 @@
 # project/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, DateField, IntegerField, \
     SelectField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo, Email

--- a/flasktaskr-05/project/tasks/forms.py
+++ b/flasktaskr-05/project/tasks/forms.py
@@ -1,7 +1,7 @@
 # project/users/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, DateField, IntegerField, \
     SelectField
 from wtforms.validators import DataRequired

--- a/flasktaskr-05/project/users/forms.py
+++ b/flasktaskr-05/project/users/forms.py
@@ -1,7 +1,7 @@
 # project/tasks/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo, Email
 

--- a/flasktaskr-06/project/tasks/forms.py
+++ b/flasktaskr-06/project/tasks/forms.py
@@ -1,7 +1,7 @@
 # project/users/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, DateField, IntegerField, \
     SelectField
 from wtforms.validators import DataRequired

--- a/flasktaskr-06/project/users/forms.py
+++ b/flasktaskr-06/project/users/forms.py
@@ -1,7 +1,7 @@
 # project/tasks/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo, Email
 

--- a/flasktaskr-07/project/tasks/forms.py
+++ b/flasktaskr-07/project/tasks/forms.py
@@ -1,7 +1,7 @@
 # project/users/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, DateField, IntegerField, \
     SelectField
 from wtforms.validators import DataRequired

--- a/flasktaskr-07/project/users/forms.py
+++ b/flasktaskr-07/project/users/forms.py
@@ -1,7 +1,7 @@
 # project/tasks/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo, Email
 

--- a/flasktaskr-08/project/tasks/forms.py
+++ b/flasktaskr-08/project/tasks/forms.py
@@ -1,7 +1,7 @@
 # project/users/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, DateField, IntegerField, \
     SelectField
 from wtforms.validators import DataRequired

--- a/flasktaskr-08/project/users/forms.py
+++ b/flasktaskr-08/project/users/forms.py
@@ -1,7 +1,7 @@
 # project/tasks/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import StringField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo, Email
 

--- a/flasktaskr_project/project/tasks/forms.py
+++ b/flasktaskr_project/project/tasks/forms.py
@@ -1,7 +1,7 @@
 # /project/tasks/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import TextField, DateField, IntegerField, \
     SelectField
 from wtforms.validators import DataRequired

--- a/flasktaskr_project/project/users/forms.py
+++ b/flasktaskr_project/project/users/forms.py
@@ -1,7 +1,7 @@
 # /project/users/forms.py
 
 
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from wtforms import TextField, PasswordField
 from wtforms.validators import DataRequired, Length, EqualTo, Email
 


### PR DESCRIPTION
Due to the FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.

I stumbled upon this warning working my way through the Real Python Course, Part 2, and decided to improve my git-knowledge a bit by submitting this pull request. Hope this finds your approval.

See also Flask-WTF change log:
https://flask-wtf.readthedocs.io/en/stable/changelog.html?highlight=flaskform#version-0-13